### PR TITLE
fix: point module field at published entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "mcpName": "io.github.Nekzus/npm-sentinel-mcp",
   "description": "NPM Sentinel MCP - A powerful Model Context Protocol (MCP) server that revolutionizes NPM package analysis through AI. Built to integrate with Claude and Anthropic AI, it provides real-time intelligence on package security, dependencies, and performance.",
   "type": "module",
-  "module": "./index.ts",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary

This updates the package `module` field to point at the published JavaScript entry in `dist`.

## Why

The published `@nekzus/mcp-server@1.18.0` package declares:

```json
"module": "./index.ts"
```

However, the npm tarball does not include a root `index.ts`. It does include `dist/index.js`, which is already used by `main`, and `dist/index.d.ts`, which is already used by `types`.

## Validation

I validated this with static package metadata checks only:

```sh
npm pack @nekzus/mcp-server@1.18.0 --ignore-scripts --json
```

Then I inspected the extracted tarball and confirmed that `package/package.json` points `module` at `./index.ts`, while `package/index.ts` is missing and `package/dist/index.js` exists.

No package scripts were run.
