### PR TITLE
fix: point module field at published entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "mcpName": "io.github.Nekzus/npm-sentinel-mcp",
   "description": "NPM Sentinel MCP - A powerful Model Context Protocol (MCP) server that revolutionizes NPM package analysis through AI. Built to integrate with Claude and Anthropic AI, it provides real-time intelligence on package security, dependencies, and performance.",
   "type": "module",
-  "module": "./index.ts",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- update `module` from the unpublished root `index.ts` source path to `./dist/index.js`
- align `module` with the published JavaScript entry and existing `main` field

## Validation
- inspected `@nekzus/mcp-server@1.18.0` with `npm pack --ignore-scripts`: root `index.ts` is absent while `dist/index.js` is present
- `node -e` check confirmed `module` and `main` now both point to `./dist/index.js`